### PR TITLE
Too early to use `LIBRARY_PACKAGE_NAME`.

### DIFF
--- a/android/src/main/java/jp/pay/reactnative/PayjpModule.kt
+++ b/android/src/main/java/jp/pay/reactnative/PayjpModule.kt
@@ -61,7 +61,7 @@ class PayjpModule(
           ?.get(0)
     } ?: Locale.getDefault()
     val clientInfo = ClientInfo.Builder()
-        .setPlugin("${BuildConfig.LIBRARY_PACKAGE_NAME}/${BuildConfig.VERSION_NAME}")
+        .setPlugin("jp.pay.reactnative/${BuildConfig.VERSION_NAME}")
         .setPublisher("payjp")
         .build()
     Payjp.init(


### PR DESCRIPTION
`LIBRARY_PACKAGE_NAME` introduced by AS 3.5.