### PR TITLE
Check outdated dependencies.

### DIFF
--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -1,0 +1,53 @@
+name: Check dependencies outdated
+
+on:
+  push # TODO: trigger weekly
+
+jobs:
+  check_outdated:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache yarn
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache node
+        uses: actions/cache@v2
+        id: node-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Cocoapods
+        uses: actions/cache@v2
+        id: pods-cache
+        with:
+          path: example/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - run: yarn --frozen-lockfile
+      - run: cd example && yarn --frozen-lockfile
+      - run: cd example/ios && pod install
+      - name: Validate outdated
+        id: validate
+        run: sh scripts/check_outdated_deps.sh > outdated.txt
+      - name: Create Issue
+        if: ${{ failure() }}
+        run: |
+          MESSAGE=$(cat outdated.txt)
+          hub issue create -m "[Bot]Found outdated dependencies." -m "$MESSAGE"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -1,7 +1,8 @@
 name: Check dependencies outdated
 
 on:
-  push # TODO: trigger weekly
+  schedule:
+    - cron: 0 0 * * 1
 
 jobs:
   check_outdated:

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -68,29 +68,31 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - GoogleUtilities/AppDelegateSwizzler (6.5.2):
+  - GoogleUtilities/AppDelegateSwizzler (6.7.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.5.2)
-  - GoogleUtilities/Logger (6.5.2):
+  - GoogleUtilities/Environment (6.7.2):
+    - PromisesObjC (~> 1.2)
+  - GoogleUtilities/Logger (6.7.2):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (6.5.2):
+  - GoogleUtilities/Network (6.7.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.5.2)"
-  - GoogleUtilities/Reachability (6.5.2):
+  - "GoogleUtilities/NSData+zlib (6.7.2)"
+  - GoogleUtilities/Reachability (6.7.2):
     - GoogleUtilities/Logger
   - OpenSSL-Universal (1.0.2.19):
     - OpenSSL-Universal/Static (= 1.0.2.19)
   - OpenSSL-Universal/Static (1.0.2.19)
   - PAYJP (1.2.5)
-  - payjp-react-native (0.4.2):
+  - payjp-react-native (0.4.3):
     - CardIO (~> 5.4.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.5.2)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
     - PAYJP (~> 1.2.5)
     - React
+  - PromisesObjC (1.2.10)
   - RCTRequired (0.62.2)
   - RCTTypeSafety (0.62.2):
     - FBLazyVector (= 0.62.2)
@@ -383,6 +385,7 @@ SPEC REPOS:
     - GoogleUtilities
     - OpenSSL-Universal
     - PAYJP
+    - PromisesObjC
     - YogaKit
 
 EXTERNAL SOURCES:
@@ -456,10 +459,11 @@ SPEC CHECKSUMS:
   FlipperKit: 6dc9b8f4ef60d9e5ded7f0264db299c91f18832e
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  GoogleUtilities: ad0f3b691c67909d03a3327cc205222ab8f42e0e
+  GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   PAYJP: 7fafdc7e00ff76584761e064ce95d8fb1fed2e80
-  payjp-react-native: 18b4c511aa142c2df512a57aa11fd3efd76ffe79
+  payjp-react-native: cfce0a6a50f6a3288098c9c8390534b4824815cb
+  PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035
   RCTTypeSafety: 93006131180074cffa227a1075802c89a49dd4ce
   React: 29a8b1a02bd764fb7644ef04019270849b9a7ac3

--- a/payjp-react-native.podspec
+++ b/payjp-react-native.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.dependency "React"
   s.dependency 'PAYJP', "~> #{payjp_sdk['ios']}"
   s.dependency 'CardIO', '~> 5.4.1'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.5.2'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
 
 end

--- a/scripts/check_outdated_deps.sh
+++ b/scripts/check_outdated_deps.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -ex
+# Check podspec dependencies outdated.
+# See payjp-react-native.podspec
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+# NOTE: Exclude PAYJP. It'll be updated by "Check latest PAYJP.SDK".
+# NOTE: Exclude React. It's managed by node modules.
+DEPS=(
+    "CardIO"
+    "GoogleUtilities"
+)
+outdated=""
+pod outdated --no-ansi --project-directory=$SCRIPT_DIR/../example/ios/ | (while read line
+    do
+        for dep in "${DEPS[@]}" ; do
+            if [[ "$line" =~ "$dep" ]] ; then
+                if [ -z "$outdated" ]; then
+                    outdated="$line"
+                else
+                    outdated=`printf "%s\n%s" "$outdated" "$line"`
+                fi
+            fi
+        done
+done
+    if [ ! -z "$outdated" ]; then
+        echo "need to update"
+        echo "$outdated";
+        exit 1;
+    fi
+)


### PR DESCRIPTION
Fixes #73 
ref #69 

# Overview

- To prevent resolution problem such as #69, added scheduled-workflow to check outdated deps of `payjp-react-native.podspec`. 
- Run [`pod outdated`](https://guides.cocoapods.org/terminal/commands.html#pod_outdated) weekly.
- If any outdated deps found, create a issue (like #73).

# Checklist

- [x] [Check outdated deps in Github Actions.](https://github.com/payjp/payjp-react-native-plugin/actions/runs/223307025)
- [x] Update deps.
  - https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleUtilities/CHANGELOG.md
- [x] Run the action weekly.
- [x] CI passed.