### PR TITLE
Fix usage of AppDelegateSwizzler

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -68,20 +68,20 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - GoogleUtilities/AppDelegateSwizzler (6.7.2):
+  - GoogleUtilities/AppDelegateSwizzler (7.0.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.7.2):
+  - GoogleUtilities/Environment (7.0.0):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.7.2):
+  - GoogleUtilities/Logger (7.0.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (6.7.2):
+  - GoogleUtilities/Network (7.0.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.7.2)"
-  - GoogleUtilities/Reachability (6.7.2):
+  - "GoogleUtilities/NSData+zlib (7.0.0)"
+  - GoogleUtilities/Reachability (7.0.0):
     - GoogleUtilities/Logger
   - OpenSSL-Universal (1.0.2.19):
     - OpenSSL-Universal/Static (= 1.0.2.19)
@@ -89,10 +89,10 @@ PODS:
   - PAYJP (1.3.0)
   - payjp-react-native (0.4.5):
     - CardIO (~> 5.4.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - PAYJP (~> 1.3.0)
-    - React
-  - PromisesObjC (1.2.10)
+    - React-Core
+  - PromisesObjC (1.2.11)
   - RCTRequired (0.63.3)
   - RCTTypeSafety (0.63.3):
     - FBLazyVector (= 0.63.3)
@@ -465,11 +465,11 @@ SPEC CHECKSUMS:
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
+  GoogleUtilities: ffb2f4159f2c897c6e8992bd7fbcdef8a300589c
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   PAYJP: 9849ef1b565d92a399825fcd7e4d2189d6f2fce9
-  payjp-react-native: 3f023dd767023c63687f2b71beaf64baca484107
-  PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
+  payjp-react-native: 10bcb535ea0d2b1da4436b590ed8ea36e38d5185
+  PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
   RCTRequired: 48884c74035a0b5b76dbb7a998bd93bcfc5f2047
   RCTTypeSafety: edf4b618033c2f1c5b7bc3d90d8e085ed95ba2ab
   React: f36e90f3ceb976546e97df3403e37d226f79d0e3

--- a/ios/Classes/RNPAYAppDelegateInterceptor.m
+++ b/ios/Classes/RNPAYAppDelegateInterceptor.m
@@ -38,11 +38,25 @@
 }
 
 - (BOOL)application:(UIApplication *)application
-            openURL:(NSURL *)URL
+            openURL:(NSURL *)url
             options:(NSDictionary<NSString *, id> *)options {
-  BOOL result =
-      [[PAYJPThreeDSecureProcessHandler sharedHandler] completeThreeDSecureProcessWithUrl:URL];
-  return result;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  return [self application:application
+                   openURL:url
+         sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+                annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+#pragma clang diagnostic pop
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (BOOL)application:(UIApplication *)application
+              openURL:(NSURL *)url
+    sourceApplication:(NSString *)sourceApplication
+           annotation:(id)annotation {
+  return [[PAYJPThreeDSecureProcessHandler sharedHandler] completeThreeDSecureProcessWithUrl:url];
+}
+#pragma clang diagnostic pop
 
 @end

--- a/ios/Classes/RNPAYCore.m
+++ b/ios/Classes/RNPAYCore.m
@@ -28,6 +28,10 @@
 
 @implementation RNPAYCore
 
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initialize

--- a/payjp-react-native.podspec
+++ b/payjp-react-native.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.static_framework = true
   
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency 'PAYJP', "~> #{payjp_sdk['ios']}"
   s.dependency 'CardIO', '~> 5.4.1'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.0'
 
 end


### PR DESCRIPTION
Fix #79 

- Update `GoogleUtilities/AppDelegateSwizzler` to 7.0
  - https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleUtilities/CHANGELOG.md#700
- Initialize AppDelegateInterceptor in the UIThread.
- Use `React-Core` instead of `React` for Xcode 12 (see https://github.com/facebook/react-native/issues/29633 ).
- Fix ignoring interceptor because of missing implementation of `application:openURL:sourceApplication:annotation`.
  - https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleUtilities/AppDelegateSwizzler/README.md