### PR TITLE
Update AGP to 4.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion rootProject.properties.get('targetSdkVersion', 29)
-        versionName pluginVersion
+        buildConfigField "String", "VERSION_NAME", "\"$pluginVersion\""
     }
     lintOptions {
         warning 'InvalidPackage'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.6.2")
+        classpath('com.android.tools.build:gradle:4.1.1')
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 07 18:08:00 JST 2020
+#Tue Dec 15 21:30:49 JST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
Android Gradle Plugin 4.1.0以降、ライブラリプロジェクトの `VERSION_NAME` はBuildConfigから削除されるため、ビルドに失敗する。

https://developer.android.com/studio/releases/gradle-plugin#version_properties_removed_from_buildconfig_class_in_library_projects

buildConfigFieldを使って明示的にVERSION_NAMEをBuildConfigに設定するよう変更した。