### PR TITLE
Remove package from manifest for new changes of Android SDK and move namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'jp.pay.reactnative'
     compileSdkVersion rootProject.properties.get('compileSdkVersion', 29)
 
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -22,3 +22,4 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>
+

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -20,8 +20,5 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   ~ SOFTWARE.
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="jp.pay.reactnative">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>
-  


### PR DESCRIPTION
Androidmanifest.xml の pakcage が廃止になり、build.gradleにパッケージIDが必須になったのでその対応です。最新のGradleでは依存として追加する際にエラーになります

参考: https://bps-tomoya.hateblo.jp/entry/2022/05/11/193325