### PR TITLE
「支払い作成時の 3Dセキュア」「顧客カードに対する 3Dセキュア」に対応

### DIFF
--- a/android/src/main/java/jp/pay/reactnative/PayjpReactNativePackage.kt
+++ b/android/src/main/java/jp/pay/reactnative/PayjpReactNativePackage.kt
@@ -31,9 +31,11 @@ import com.facebook.react.uimanager.ViewManager
 class PayjpReactNativePackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
     val cardFormModule = PayjpCardFormModule(reactContext)
+    val threeDSecureProcessHandlerModule = PayjpThreeDSecureProcessHandlerModule(reactContext)
     return listOf<NativeModule>(
         PayjpModule(reactContext, cardFormModule),
-        cardFormModule
+        cardFormModule,
+        threeDSecureProcessHandlerModule
     )
   }
 

--- a/android/src/main/java/jp/pay/reactnative/PayjpThreeDSecureProcessHandlerModule.kt
+++ b/android/src/main/java/jp/pay/reactnative/PayjpThreeDSecureProcessHandlerModule.kt
@@ -1,0 +1,75 @@
+package jp.pay.reactnative
+
+import android.app.Activity
+import android.content.Intent
+import com.facebook.react.bridge.ActivityEventListener
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.module.annotations.ReactModule
+import jp.pay.android.verifier.PayjpVerifier
+import jp.pay.android.verifier.ui.PayjpThreeDSecureResult
+import jp.pay.android.verifier.ui.PayjpThreeDSecureResultCallback
+
+
+@ReactModule(name = PayjpThreeDSecureProcessHandlerModule.MODULE_NAME)
+class PayjpThreeDSecureProcessHandlerModule(
+  private val reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext), ActivityEventListener {
+
+  companion object {
+    const val MODULE_NAME = "RNPAYThreeDSecureProcessHandler"
+  }
+
+  private var pendingPromise: Promise? = null
+
+  override fun getName(): String = MODULE_NAME
+
+  init {
+    reactContext.addActivityEventListener(this)
+  }
+
+  @ReactMethod
+  fun startThreeDSecureProcess(resourceId: String, promise: Promise) {
+    val activity: Activity? = reactContext.currentActivity
+    if (activity == null) {
+      promise.reject("NO_ACTIVITY", "Current activity is null")
+      return
+    }
+    if (pendingPromise != null) {
+      promise.reject("PENDING_OPERATION", "Another 3DS process is already in progress.")
+      return
+    }
+    this.pendingPromise = promise
+    PayjpVerifier.startThreeDSecureFlow(resourceId, activity)
+  }
+
+  override fun onActivityResult(
+    activity: Activity,
+    requestCode: Int,
+    resultCode: Int,
+    data: Intent?
+  ) {
+    pendingPromise?.let { promise ->
+      PayjpVerifier.handleThreeDSecureResult(requestCode, object : PayjpThreeDSecureResultCallback {
+        override fun onResult(result: PayjpThreeDSecureResult) {
+          when (result) {
+            is PayjpThreeDSecureResult.SuccessResourceId -> {
+              promise.resolve(null)
+            }
+            PayjpThreeDSecureResult.Canceled -> {
+              promise.reject("THREE_D_SECURE_CANCELED", "ThreeDSecure process was canceled by user.")
+            }
+            else -> {
+              promise.reject("THREE_D_SECURE_UNKNOWN", "Unknown ThreeDSecure result.")
+            }
+          }
+          pendingPromise = null
+        }
+      })
+    }
+  }
+
+  override fun onNewIntent(intent: Intent?) {}
+}

--- a/example/app.json
+++ b/example/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "jp.pay.example",
     "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/images/splash.png",
@@ -14,7 +14,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.PAYJPExample",
+      "bundleIdentifier": "jp.pay.example.PAYJPExample",
       "infoPlist": {
         "NSCameraUsageDescription": "This app uses the camera to scan QR codes."
       },
@@ -29,7 +29,7 @@
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.anonymous.PAYJPExample"
+      "package": "jp.pay.example.PAYJPExample"
     },
     "web": {
       "bundler": "metro",
@@ -37,7 +37,12 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router",
+      [
+        "expo-router",
+        {
+          "origin": "jp.pay.example://"
+        }
+      ],
       "@config-plugins/detox",
       "./config/add-android-dependencies",
       "./config/payjp-three-d-secure"

--- a/example/app/(tabs)/_layout.tsx
+++ b/example/app/(tabs)/_layout.tsx
@@ -33,6 +33,21 @@ export default function TabLayout() {
                     ),
                 }}
             />
+            <Tabs.Screen
+                name="tds/index"
+                options={{
+                    title: '3Dセキュア',
+                    tabBarIcon: ({ color, focused }) => (
+                        <TabBarIcon name={focused ? 'shield' : 'shield-outline'} color={color} />
+                    ),
+                }}
+            />
+            <Tabs.Screen
+                name="tds/finish"
+                options={{
+                    href: null,
+                }}
+            />
         </Tabs>
     );
 }

--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -54,6 +54,7 @@ export default function HomeScreen() {
                 PayjpCardForm.startCardForm({
                     cardFormType: formType,
                     extraAttributes: selectedOption.attributes,
+                    useThreeDSecure: true,
                 });
             },
         );

--- a/example/app/(tabs)/tds/finish.tsx
+++ b/example/app/(tabs)/tds/finish.tsx
@@ -1,0 +1,67 @@
+import { StyleSheet, TouchableOpacity } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import React from 'react';
+import { useRouter } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function ThreeDSecureFinishScreen() {
+    const router = useRouter();
+
+    const handleReturn = () => {
+        router.replace('/tds');
+    };
+
+    return (
+        <SafeAreaView style={{ flex: 1 }}>
+            <ThemedView style={styles.container}>
+                <ThemedView style={styles.resultContainer}>
+                    <ThemedText style={styles.resultText}>3Dセキュア認証が終了しました。</ThemedText>
+                    <ThemedText>
+                        この結果をサーバーサイドに伝え、完了処理や結果のハンドリングをおこなってください。
+                    </ThemedText>
+                    <TouchableOpacity style={styles.button} onPress={handleReturn}>
+                        <ThemedText style={styles.buttonText}>戻る</ThemedText>
+                    </TouchableOpacity>
+                </ThemedView>
+            </ThemedView>
+            <StatusBar style="auto" />
+        </SafeAreaView>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        padding: 20,
+        paddingTop: 15,
+        justifyContent: 'center',
+    },
+    resultContainer: {
+        gap: 20,
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 1,
+        paddingVertical: 40,
+    },
+    button: {
+        backgroundColor: '#4287f5',
+        padding: 14,
+        borderRadius: 8,
+        alignItems: 'center',
+        marginVertical: 8,
+        minWidth: 200,
+    },
+    buttonText: {
+        color: '#fff',
+        fontWeight: 'bold',
+        fontSize: 16,
+    },
+    resultText: {
+        fontSize: 18,
+        fontWeight: 'bold',
+        textAlign: 'center',
+        marginBottom: 8,
+    },
+});

--- a/example/app/(tabs)/tds/index.tsx
+++ b/example/app/(tabs)/tds/index.tsx
@@ -1,0 +1,155 @@
+import { StyleSheet, TextInput, TouchableOpacity, View, ScrollView, SafeAreaView } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import React, { useState } from 'react';
+import { PayjpThreeDSecure } from 'payjp-react-native';
+import { Linking } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { useRouter } from 'expo-router';
+
+export default function ThreeDSecureScreen() {
+    const [resourceId, setResourceId] = useState('');
+    const [resultMessage, setResultMessage] = useState('');
+    const router = useRouter();
+
+    const startThreeDSecure = async () => {
+        try {
+            if (!resourceId) {
+                setResultMessage('リソースIDを入力してください');
+                return;
+            }
+
+            setResultMessage('3Dセキュア認証を開始します...');
+            await PayjpThreeDSecure.startThreeDSecureProcess(
+                resourceId,
+                () => {
+                    setResultMessage('3Dセキュア認証が完了しました');
+                    router.push('/tds/finish');
+                },
+                (error: { message: string; code: number }) => {
+                    console.error('3Dセキュア認証が失敗しました', error);
+                    setResultMessage(`エラー: ${error.message}`);
+                },
+            );
+        } catch (e: any) {
+            console.error('The 3D Secure process promise was rejected:', e);
+        }
+    };
+
+    const handleChargeTDSLink = () => {
+        Linking.openURL('https://pay.jp/docs/charge-tds');
+    };
+
+    const handleCustomerCardTDSLink = () => {
+        Linking.openURL('https://pay.jp/docs/customer-card-tds');
+    };
+
+    return (
+        <SafeAreaView style={{ flex: 1 }}>
+            <ScrollView>
+                <ThemedView style={styles.container}>
+                    <ThemedText type="subtitle" style={styles.title}>
+                        3Dセキュア
+                    </ThemedText>
+                    <ThemedView style={styles.formContainer}>
+                        <TextInput
+                            style={styles.input}
+                            placeholder="リソースID (charge_xxxまたはcus_xxx_cad_xxx)"
+                            value={resourceId}
+                            onChangeText={setResourceId}
+                        />
+
+                        <TouchableOpacity style={styles.button} onPress={startThreeDSecure}>
+                            <ThemedText style={styles.buttonText}>3Dセキュア開始</ThemedText>
+                        </TouchableOpacity>
+
+                        {resultMessage ? <ThemedText style={styles.statusText}>{resultMessage}</ThemedText> : null}
+                        <ThemedText style={styles.instruction}>
+                            1. 下記を参考に、先にサーバーサイドで支払い、または3Dセキュアリクエストを作成してください。
+                        </ThemedText>
+
+                        <View style={styles.linkContainer}>
+                            <ThemedText style={styles.linkLabel}>支払い作成時の3Dセキュア：</ThemedText>
+                            <TouchableOpacity onPress={handleChargeTDSLink}>
+                                <ThemedText style={styles.urlText}>https://pay.jp/docs/charge-tds</ThemedText>
+                            </TouchableOpacity>
+                        </View>
+
+                        <View style={styles.linkContainer}>
+                            <ThemedText style={styles.linkLabel}>顧客カードに対する3Dセキュア：</ThemedText>
+                            <TouchableOpacity onPress={handleCustomerCardTDSLink}>
+                                <ThemedText style={styles.urlText}>https://pay.jp/docs/customer-card-tds</ThemedText>
+                            </TouchableOpacity>
+                        </View>
+
+                        <ThemedText style={styles.instruction}>
+                            2. 作成したリソースのIDを上記に入力して3Dセキュアを開始してください。
+                        </ThemedText>
+
+                        <ThemedText style={styles.instruction}>
+                            3.
+                            立ち上がった画面が閉じ、認証が終了したら、ドキュメントを参考にサーバーサイドにて結果を確認してください。
+                        </ThemedText>
+                    </ThemedView>
+                </ThemedView>
+            </ScrollView>
+            <StatusBar style="auto" />
+        </SafeAreaView>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        padding: 20,
+        paddingTop: 15,
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        marginBottom: 16,
+    },
+    formContainer: {
+        gap: 20,
+    },
+    instruction: {
+        fontSize: 15,
+        lineHeight: 22,
+        marginBottom: 4,
+    },
+    linkContainer: {
+        marginBottom: 8,
+    },
+    linkLabel: {
+        marginBottom: 4,
+    },
+    input: {
+        borderWidth: 1,
+        borderColor: '#ddd',
+        borderRadius: 8,
+        padding: 12,
+        backgroundColor: '#fff',
+        fontSize: 14,
+        marginVertical: 8,
+    },
+    button: {
+        backgroundColor: '#4287f5',
+        padding: 14,
+        borderRadius: 8,
+        alignItems: 'center',
+        marginVertical: 8,
+    },
+    buttonText: {
+        color: '#fff',
+        fontWeight: 'bold',
+        fontSize: 16,
+    },
+    urlText: {
+        color: '#4287f5',
+        textDecorationLine: 'underline',
+    },
+    statusText: {
+        marginTop: 8,
+        color: '#f44336',
+    },
+});

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -7167,7 +7167,7 @@ path-type@^4.0.0:
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 payjp-react-native@../:
-  version "0.8.4"
+  version "0.9.0"
 
 picocolors@^1.0.0, picocolors@^1.0.1:
   version "1.0.1"

--- a/ios/Classes/RNPAYThreeDSecureProcessHandler.h
+++ b/ios/Classes/RNPAYThreeDSecureProcessHandler.h
@@ -20,7 +20,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#import "RNPAY.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+@import PAYJP;
 
-NSString *const RNPAYErrorDomain = @"RNPAYErrorDomain";
-NSString *const RNPAYPluginVersion = @"0.9.0";
+@interface RNPAYThreeDSecureProcessHandler
+    : RCTEventEmitter <RCTBridgeModule, PAYJPThreeDSecureProcessHandlerDelegate>
+
+@end

--- a/ios/Classes/RNPAYThreeDSecureProcessHandler.m
+++ b/ios/Classes/RNPAYThreeDSecureProcessHandler.m
@@ -1,0 +1,96 @@
+/*
+ *
+ * Copyright (c) 2020 PAY, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#import "RNPAYThreeDSecureProcessHandler.h"
+@import PAYJP;
+
+@interface RNPAYThreeDSecureProcessHandler () <PAYJPThreeDSecureProcessHandlerDelegate>
+
+@property(nonatomic, strong) RCTPromiseResolveBlock pendingResolve;
+@property(nonatomic, strong) RCTPromiseRejectBlock pendingReject;
+
+@end
+
+@implementation RNPAYThreeDSecureProcessHandler
+
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
+}
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(startThreeDSecureProcess : (NSString *)resourceId resolve : (
+    RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject) {
+  if (self.pendingResolve != nil || self.pendingReject != nil) {
+    reject(@"PENDING_OPERATION", @"Another 3DS process is already in progress.", nil);
+    return;
+  }
+
+  self.pendingResolve = resolve;
+  self.pendingReject = reject;
+
+  __weak typeof(self) wself = self;
+  dispatch_async([self methodQueue], ^{
+    PAYJPThreeDSecureProcessHandler *handler = [PAYJPThreeDSecureProcessHandler sharedHandler];
+
+    UIViewController *hostViewController =
+        UIApplication.sharedApplication.keyWindow.rootViewController;
+    while (hostViewController.presentedViewController) {
+      hostViewController = hostViewController.presentedViewController;
+    }
+    if ([hostViewController isKindOfClass:[UINavigationController class]]) {
+      UINavigationController *navigationController = (UINavigationController *)hostViewController;
+      hostViewController = navigationController.visibleViewController;
+    }
+
+    [handler startThreeDSecureProcessWithViewController:hostViewController
+                                               delegate:wself
+                                             resourceId:resourceId];
+  });
+}
+
+#pragma mark - ThreeDSecureProcessHandlerDelegate
+
+- (void)threeDSecureProcessHandlerDidFinish:(PAYJPThreeDSecureProcessHandler *)handler
+                                     status:(ThreeDSecureProcessStatus)status {
+  if (self.pendingResolve == nil && self.pendingReject == nil) {
+    return;
+  }
+
+  switch (status) {
+    case ThreeDSecureProcessStatusCompleted:
+      if (self.pendingResolve) {
+        self.pendingResolve([NSNull null]);
+      }
+      break;
+    case ThreeDSecureProcessStatusCanceled:
+      if (self.pendingReject) {
+        self.pendingReject(@"THREE_D_SECURE_CANCELED",
+                           @"ThreeDSecure process was canceled by user.", nil);
+      }
+      break;
+
+      self.pendingResolve = nil;
+      self.pendingReject = nil;
+  }
+
+  @end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "payjp-react-native",
   "description": "A React Native plugin for PAY.JP SDK",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "author": {
     "name": "PAY.JP",
     "email": "support@pay.jp",

--- a/src/ThreeDSecure.ts
+++ b/src/ThreeDSecure.ts
@@ -1,0 +1,40 @@
+// LICENSE : MIT
+import { NativeModules } from 'react-native';
+
+/**
+ * 3Dセキュア処理が成功したときに実行されるリスナー
+ */
+export type OnThreeDSecureProcessSucceeded = () => void;
+
+/**
+ * 3Dセキュア処理が失敗したときに実行されるリスナー
+ *
+ * @param error エラー情報
+ */
+export type OnThreeDSecureProcessFailed = (error: { message: string; code: number }) => void;
+
+const { RNPAYThreeDSecureProcessHandler } = NativeModules;
+
+/**
+ * リソースIDを使用して3Dセキュア処理を開始します。
+ * 「支払い時」「顧客カードに対する3Dセキュア」の両方に対応しています。
+ *
+ * @param resourceId charge_xxx（支払い時）またはcus_xxx_car_xxx（顧客カード）形式のリソースID
+ * @param onSucceeded 3Dセキュア処理が成功したときに実行されるコールバック
+ * @param onFailed 3Dセキュア処理が失敗したときに実行されるコールバック
+ */
+export const startThreeDSecureProcess = async (
+    resourceId: string,
+    onSucceeded: OnThreeDSecureProcessSucceeded,
+    onFailed: OnThreeDSecureProcessFailed,
+): Promise<void> => {
+    try {
+        await RNPAYThreeDSecureProcessHandler.startThreeDSecureProcess(resourceId);
+        onSucceeded();
+    } catch (nativeError: any) {
+        const errorMessage = `Native Code: ${nativeError.code}, Message: ${nativeError.message || 'Unknown error'}`;
+        const errorPayload = { message: errorMessage, code: 1 };
+        onFailed(errorPayload);
+        throw nativeError;
+    }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import * as PayjpApplePay from './ApplePay';
 import * as PayjpCardForm from './CardForm';
 import * as PayjpCore from './Core';
+import * as PayjpThreeDSecure from './ThreeDSecure';
 
-export { PayjpCore, PayjpCardForm, PayjpApplePay };
+export { PayjpCore, PayjpCardForm, PayjpApplePay, PayjpThreeDSecure };
 export * from './models';

--- a/test/ThreeDSecure.test.ts
+++ b/test/ThreeDSecure.test.ts
@@ -1,0 +1,91 @@
+// LICENSE : MIT
+import type * as PayjpThreeDSecureType from '../src/ThreeDSecure';
+
+let currentMockEmitterInstance: {
+    listeners: Record<string, (...args: any[]) => void>;
+    removers: Record<string, { remove: jest.Mock }>;
+    addListener: jest.Mock;
+    _simulateEvent: jest.Mock;
+    _getRemoveMockForEvent: jest.Mock;
+} | null = null;
+
+const mockRNPAYThreeDSecureProcessHandler = {
+    startThreeDSecureProcess: jest.fn(),
+};
+
+jest.mock('react-native', () => {
+    const NativeEventEmitterMock = jest.fn().mockImplementation(() => {
+        const instance = {
+            listeners: {} as Record<string, (...args: any[]) => void>,
+            removers: {} as Record<string, { remove: jest.Mock }>,
+            addListener: jest.fn(function (this: any, eventName: string, callback: (...args: any[]) => void) {
+                this.listeners[eventName] = callback;
+                const remover = {
+                    remove: jest.fn(() => {}),
+                };
+                this.removers[eventName] = remover;
+                return remover;
+            }),
+            _simulateEvent: jest.fn(function (this: any, eventName: string, ...args: any[]) {
+                if (typeof this.listeners[eventName] === 'function') {
+                    this.listeners[eventName](...args);
+                }
+            }),
+            _getRemoveMockForEvent: jest.fn(function (this: any, eventName: string): jest.Mock | undefined {
+                return this.removers[eventName]?.remove;
+            }),
+        };
+        currentMockEmitterInstance = instance;
+        return instance;
+    });
+
+    return {
+        NativeEventEmitter: NativeEventEmitterMock,
+        NativeModules: {
+            RNPAYThreeDSecureProcessHandler: mockRNPAYThreeDSecureProcessHandler,
+        },
+    };
+});
+
+let PayjpThreeDSecure: typeof PayjpThreeDSecureType;
+
+describe('PayjpThreeDSecure', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        currentMockEmitterInstance = null;
+        mockRNPAYThreeDSecureProcessHandler.startThreeDSecureProcess.mockClear();
+        PayjpThreeDSecure = require('../src/ThreeDSecure');
+        const emitter = currentMockEmitterInstance as any;
+        if (emitter && emitter.addListener) {
+            emitter.addListener.mockClear();
+        }
+    });
+
+    describe('startThreeDSecureProcess', () => {
+        it('calls native method with resourceId', async () => {
+            const resourceId = 'charge_xxx';
+            const onSucceeded = jest.fn();
+            const onFailed = jest.fn();
+            await PayjpThreeDSecure.startThreeDSecureProcess(resourceId, onSucceeded, onFailed);
+            expect(mockRNPAYThreeDSecureProcessHandler.startThreeDSecureProcess).toHaveBeenCalledTimes(1);
+            expect(mockRNPAYThreeDSecureProcessHandler.startThreeDSecureProcess).toHaveBeenCalledWith(resourceId);
+            expect(onSucceeded).toHaveBeenCalledTimes(1);
+            expect(onFailed).not.toHaveBeenCalled();
+        });
+        it('calls onFailed if native throws', async () => {
+            const resourceId = 'charge_xxx';
+            const onSucceeded = jest.fn();
+            const onFailed = jest.fn();
+            const error = { code: 999, message: 'fail' };
+            mockRNPAYThreeDSecureProcessHandler.startThreeDSecureProcess.mockImplementationOnce(() => {
+                throw error;
+            });
+            await expect(PayjpThreeDSecure.startThreeDSecureProcess(resourceId, onSucceeded, onFailed)).rejects.toBe(
+                error,
+            );
+            expect(onSucceeded).not.toHaveBeenCalled();
+            expect(onFailed).toHaveBeenCalledTimes(1);
+            expect(onFailed).toHaveBeenCalledWith({ message: expect.stringContaining('Native Code: 999'), code: 1 });
+        });
+    });
+});


### PR DESCRIPTION
「支払い作成時の 3Dセキュア」「顧客カードに対する 3Dセキュア」に対応するための変更です。
0.8.6 → 0.9.0 へバージョン番号を更新します。

## 変更点
- iOS SDK/Android SDKの変更を取り込み
  - iOS https://github.com/payjp/payjp-ios/pull/95
  - Android https://github.com/payjp/payjp-android/pull/77
- RNに`startThreeDSecureProcess(resourceId: String, promise: Promise) `を追加
- PAYJPExampleの更新

| 開始画面 | コールバック先 |
|--------|--------|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-05-11 at 11 26 10](https://github.com/user-attachments/assets/067e4f7c-1333-48bf-a800-7e8b9c5f241c) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-05-11 at 11 26 18](https://github.com/user-attachments/assets/bb774154-b99d-4e41-af92-dee1ccb3b27d) | 