### PR TITLE
podspecからCardIOの記述削除

### DIFF
--- a/payjp-react-native.podspec
+++ b/payjp-react-native.podspec
@@ -19,9 +19,6 @@ Pod::Spec.new do |s|
   
   s.dependency "React-Core"
   s.dependency 'PAYJP', "~> #{payjp_sdk['ios']}"
-  # NOTE: If you need to scan card in your card form, please add the following dependency to your Podfile directly.
-  # as default, we don't include this dependency because it causes a issue in arm64 simulator build.
-  # s.dependency 'CardIO', '~> 5.4.1'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.2'
 
 end


### PR DESCRIPTION
## 概要

* Androidに合わせてカードスキャナープラグイン追加のコメント削除
* iOSは実装上に記述が見つからなかったので、podspecのコメント削除のみ

## 関連Issues

* https://github.com/payjp/payjp-android/issues/80


### 動作検証

* Pixel 7 Pro（emulator：Android 13）
    - [x] ビルド確認
    - [x] カード登録
* iPhone 16 Pro（simulator：iOS 18.1）
    - [x] ビルド確認
    - [x] カード登録
