### PR TITLE
upgrade actions node24

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  USER_NODE_VERSION: 20
+  USER_NODE_VERSION: 22
   USER_JAVA_VERSION: 17
 
 jobs:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.USER_NODE_VERSION }}
           cache: 'yarn'
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.USER_NODE_VERSION }}
           cache: 'yarn'
@@ -49,8 +49,8 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.USER_NODE_VERSION }}
           cache: 'yarn'

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 10.x
+          node-version: 22
           cache: 'yarn'
           cache-dependency-path: |
             yarn.lock

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -14,8 +14,8 @@ jobs:
   check_outdated:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 10.x
       - name: Get yarn cache directory path

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -1,10 +1,5 @@
 name: Check dependencies outdated
 
-env:
-  CACHE_VERSION_YARN: 1
-  CACHE_VERSION_NODE_MODULES: 1
-  CACHE_VERSION_PODS: 1
-
 on:
   schedule:
     - cron: 0 0 * * 1
@@ -18,35 +13,17 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 10.x
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache yarn
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ env.CACHE_VERSION_YARN }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.CACHE_VERSION_YARN }}-
-      - name: Cache node
-        uses: actions/cache@v2
-        id: node-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-node-${{ env.CACHE_VERSION_NODE_MODULES }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.CACHE_VERSION_NODE_MODULES }}-
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            example/yarn.lock
       - name: Cache Cocoapods
-        uses: actions/cache@v2
-        id: pods-cache
+        uses: actions/cache@v4
         with:
           path: example/ios/Pods
-          key: ${{ runner.os }}-pods-${{ env.CACHE_VERSION_PODS }}-${{ hashFiles('example/ios/Podfile.lock') }}
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-pods-${{ env.CACHE_VERSION_PODS }}-
+            ${{ runner.os }}-pods-
       - run: yarn --frozen-lockfile
       - run: cd example && yarn --frozen-lockfile
       - run: cd example/ios && pod install

--- a/.github/workflows/check_latest_sdk.yml
+++ b/.github/workflows/check_latest_sdk.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           repository: payjp/payjp-android
           release-only: true
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Update with latest sdk
         run: |
           jq '. + { ios: "${{ steps.latest-ios.outputs.tag }}", android: "${{ steps.latest-android.outputs.tag }}"}' sdkconfig.json > tmp.json && mv tmp.json sdkconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ buck-out/
 
 # Brew
 Brewfile.lock.json
+
+# claude
+.serena


### PR DESCRIPTION
## 概要
<!-- なぜこの変更が必要か、ビジネス/セキュリティ要件などとの関連を記載して下さい -->
https://app.notion.com/p/binc/GitHub-Action-Node-js-32784e6978c280e4876eedc980e7223b
GitHub ActionsランナーのNode.js 20が2026年4月にEOLとなり、2026年6月16日からNode 24がデフォルト化されます。
これに伴い、ワークフローで使用しているアクションをNode 24対応バージョンへ更新します。


対象 | アップグレード後バージョン
-- | --
actions/checkout@v3 | ≥ @v5 （推奨： @v6.0.3
actions/setup-node@v4 | ≥ @v6 ⚠️注意点あり https://hiratake.dev/blog/20251018/
slackapi/slack-github-action@v2.0.0 | ≥ @v3.0.1 （推奨： @v3.0.3 ）
softprops/action-gh-release@v2 | = @v3.0.0

＊バージョンの指定方法は、既存の表記に合わせる。

## 変更点
<!-- コードの変更によって、アプリケーションや環境に生じる具体的な変化について明確に記載して下さい -->
- リリースフローなどGitHubアクションがNode 24対応バージョンで実行される。

## 確認内容
<!-- テストや動作確認した内容と結果を記載して下さい -->
- [x] ブランチ作成、マージ、リリース時のgithubアクションが正常に動作すること。

## リリース手順
<!-- リリース時に必要な手順を記載して下さい。定常的な手順以外の特別な手順があれば追記して下さい -->
本番環境へのリリースはなし。

## ロールバック手順
<!-- ロールバック時に必要な手順を記載して下さい。定常的な手順以外の特別な手順があれば追記して下さい -->
1. revert commit による切り戻し。